### PR TITLE
feat: Created +layout.svelte

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,10 @@
+<script>
+  let { children } = $props();
+</script>
+
+<svelte:head>
+  <title>Healthy Urban Living Lab</title>
+  <meta name="description" content="Healthy Urban Living Lab is een living lab van de Hogeschool van Amsterdam, dat samen met haar partners de ontwikkeling van het Bajeskwartier in Amsterdam ondersteunt door middel van onderzoeksprojecten met studenten en partners." />
+</svelte:head>
+
+{@render children()}


### PR DESCRIPTION
## What does this change?

- #7

Created an initial +layout.svelte which contains a `svelte:head` element to give the page a basic title, and renders its children like a layout should.