### PR TITLE
feat: #28 - Add content to network page

### DIFF
--- a/src/lib/atoms/DirectusImage.svelte
+++ b/src/lib/atoms/DirectusImage.svelte
@@ -12,12 +12,14 @@
   } = $props()
 
   const URL = "https://fdnd-agency.directus.app/assets/"
+  const colorBg = "321f07"
+  const colorText = "12ddef"
 </script>
 
 {#if imageId === ""}
 <!-- Use placehold.co API to generate a custom placeholder image -->
 	<img
-		src="https://placehold.co/{width}x{height}/c29f9d/3e2518?text=Geen+foto+beschikbaar"
+		src="https://placehold.co/{width}x{height}/{colorBg}/{colorText}?text=Geen+foto+beschikbaar"
 		{width}
 		{height}
 		{alt}

--- a/src/lib/molecules/OverviewItem.svelte
+++ b/src/lib/molecules/OverviewItem.svelte
@@ -6,7 +6,7 @@
     imageAlt,
 		width,
 		height,
-    href,
+    href = null,
 		itemClass = '',
     contentClass = '',
     children,
@@ -14,11 +14,20 @@
 	} = $props();
 </script>
 
-<li class={itemClass}>
-  <a {href}>
-    <DirectusImage imageId={image.filename_disk} {width} {height} alt={imageAlt} {loading} />
+{#if href}
+  <li class={itemClass}>
+    <a {href}>
+      <DirectusImage imageId={image?.filename_disk ?? ""} {width} {height} alt={imageAlt} {loading} />
+		<div class={contentClass}>
+      {@render children()}
+      </div>
+    </a>
+  </li>
+{:else}
+  <li class={itemClass}>
+    <DirectusImage imageId={image?.filename_disk ?? ""} {width} {height} alt={imageAlt} {loading} />
 		<div class={contentClass}>
       {@render children()}
     </div>
-	</a>
-</li>
+  </li>
+{/if}

--- a/src/lib/organisms/PeopleOverview.svelte
+++ b/src/lib/organisms/PeopleOverview.svelte
@@ -1,0 +1,36 @@
+<script>
+  import OverviewItem from '$lib/molecules/OverviewItem.svelte';
+
+	let { people } = $props();
+</script>
+
+{#if people && people.length > 0}
+	<ul>
+		{#each people as person (person.id)}
+			<OverviewItem
+				image={(person.image ?? null)}
+        imageAlt={person.name}
+        width={person.image?.width ?? 600}
+        height={person.image?.height ?? 400}
+        itemClass={$css("person-card")}
+        contentClass={$css("person-card-content")}
+			>
+        <h2>{person.name}</h2>
+        <p>{person.position}</p>
+        <p>{person.partners[0]?.name}</p>
+      </OverviewItem>
+		{/each}
+	</ul>
+{:else}
+	<p>Geen personen gevonden. Probeer het later opnieuw.</p>
+{/if}
+
+<style>
+  .person-card {
+    
+  }
+
+  .person-card-content {
+
+  }
+</style>

--- a/src/lib/organisms/ProjectsOverview.svelte
+++ b/src/lib/organisms/ProjectsOverview.svelte
@@ -10,9 +10,11 @@
 			<OverviewItem
 				image={project.cover_image}
         imageAlt={project.title}
+        width={project.cover_image?.width}
+        height={project.cover_image?.height}
 				href={`/projecten/${project.slug}`}
-        itemClass="project-card"
-        contentClass="project-card-content"
+        itemClass={$css("project-card")}
+        contentClass={$css("project-card-content")}
 			>
         <h2>{project.title}</h2>
         <p>{@html project.description}</p>
@@ -24,3 +26,8 @@
 {:else}
 	<p>Geen projecten gevonden. Probeer het later opnieuw.</p>
 {/if}
+
+<style>
+  .project-card {}
+  .project-card-content {}
+</style>

--- a/src/routes/netwerk/+page.svelte
+++ b/src/routes/netwerk/+page.svelte
@@ -1,6 +1,12 @@
 <script>
+	import PeopleOverview from "$lib/organisms/PeopleOverview.svelte";
+
 	let { data } = $props();
 </script>
 
-<h1>Netwerk</h1>
-<p>Hier komt de netwerk pagina</p>
+<main>
+  <h1>Netwerk</h1>
+  <p>Netwerk pagina beschrijving</p>
+  <PeopleOverview people={data.people} />
+</main>
+


### PR DESCRIPTION
## What does this change?

- #28 

Added content to network page. Added non-link version of OverviewItem for if no href is given. Also added svelte-css-rune classes to ProjectsOverview for styling in the future. Improved DirectusImage placeholder to use better colours.
