### PR TITLE
Feature/projecten

### DIFF
--- a/src/routes/projecten/+page.server.js
+++ b/src/routes/projecten/+page.server.js
@@ -1,0 +1,7 @@
+export async function load({ fetch }) {
+    const response = await fetch("https://fdnd-agency.directus.app/items/hull_projects");
+    const data = await response.json();
+
+    console.log(data.data);
+return { projects: data.data }; 
+}

--- a/src/routes/projecten/+page.svelte
+++ b/src/routes/projecten/+page.svelte
@@ -1,2 +1,158 @@
-<h1>Projecten</h1>
-<p>Hier komt de projecten pagina</p>
+<script>
+    export let data;
+    const { projects } = data;
+    export let title = 'Projecten';
+    const ASSETS_URL = "https://fdnd-agency.directus.app/assets"
+</script>
+  
+<section class="container">
+    <h2 class="title">{title}</h2>
+    <div>
+        {#each projects as project}
+        <a href={`/projecten/${project.slug}`}>
+            <picture>
+              <source 
+                type="image/webp"
+                srcset={`
+                  ${ASSETS_URL}/${project.cover_image}?format=webp&width=250&quality=80&fit=cover 250w,
+                  ${ASSETS_URL}/${project.cover_image}?format=webp&width=400&quality=80&fit=cover 400w,
+                  ${ASSETS_URL}/${project.cover_image}?format=webp&width=800&quality=80&fit=cover 800w
+                `}
+                sizes="
+                (max-width: 500px) 100vw,
+                (max-width: 1000px) 50vw,
+                33vw
+              "
+              />
+  
+              <source 
+                type="image/avif"
+                srcset={`
+                  ${ASSETS_URL}/${project.cover_image}?format=avif&width=250&quality=80&fit=cover 250w,
+                  ${ASSETS_URL}/${project.cover_image}?format=avif&width=400&quality=80&fit=cover 400w,
+                  ${ASSETS_URL}/${project.cover_image}?format=avif&width=800&quality=80&fit=cover 800w
+                `}
+                sizes="
+                (max-width: 500px) 100vw,
+                (max-width: 1000px) 50vw,
+                33vw
+              "
+              />
+  
+              <img 
+                src={`${ASSETS_URL}/${project.cover_image}?format=jpg&width=400&quality=80&fit=cover`} 
+                srcset={`
+                  ${ASSETS_URL}/${project.cover_image}?format=jpg&width=250&quality=80&fit=cover 250w,
+                  ${ASSETS_URL}/${project.cover_image}?format=jpg&width=400&quality=80&fit=cover 400w,
+                  ${ASSETS_URL}/${project.cover_image}?format=jpg&width=800&quality=80&fit=cover 800w
+                `}
+                sizes="
+                (max-width: 500px) 100vw,
+                (max-width: 1000px) 50vw,
+                33vw
+              "
+                loading="lazy"
+                alt={project.title}
+              />
+            </picture>
+  
+            <div class="overlay">
+              <p>{project.title}</p>
+              <span class="arrow"></span>
+            </div>
+        </a>
+        {/each}
+    </div>
+</section>
+
+<style>
+div{
+    width: 100%;
+    columns: 3 250px;
+}
+section{
+  padding: 0 1em;
+  h2{
+    display: flex;
+    justify-content: center;
+    margin-top: var(--spacing-md);
+    margin-bottom: var(--spacing-md);
+  }
+}
+div a {
+    position: relative;
+    display: block;
+    overflow: hidden;
+    border-radius: 8px;
+    margin-bottom: 1rem;
+}
+div img {
+    width: 100%;
+    height: clamp(300px, 20vw, 300px);
+    object-fit: cover;
+    display: block;
+    border-radius: 8px;
+    transition: transform 0.3s ease;
+}
+/* Overlay */
+div .overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 1rem;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+}
+div .overlay p {
+    color: var(--color-neutral1-l3);
+    font-family: Urbanist, sans-serif;
+    font-size: clamp(1rem, 2vw, 1.5rem);
+    transform: translateY(-20px);
+    transition: transform 0.3s ease;
+}
+div .overlay .arrow {
+    position: absolute;
+    bottom: clamp(1rem, 2vw, 2rem);
+    right: clamp(1rem, 2vw, 2rem);
+    width: clamp(1rem, 2vw, 2rem);
+    height: clamp(1rem, 2vw, 2rem);
+    border-top: 2px solid var(--color-neutral1-l3);
+    border-right: 2px solid var(--color-neutral1-l3);
+    transform: rotate(45deg) translateX(0);
+    transition: transform 0.3s ease;
+}
+/* Hover effect */
+div a img {
+    transition: transform 0.3s ease;
+}
+div .overlay {
+    opacity: 1;
+    pointer-events: auto;
+    transition: opacity 0.3s ease;
+}
+div .overlay p {
+    transform: translateY(0);
+    transition: transform 0.3s ease;
+}
+@media (min-width: 548px) {
+  div .overlay {
+    opacity: 0;
+    pointer-events: none;
+  }
+  div a:hover img {
+    transform: scale(1.05);
+  }
+  div a:hover .overlay {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  div img{
+    height: auto;
+  }
+}
+</style>


### PR DESCRIPTION
## What does this change?

- Dynamische weergave van projecten via {#each projects as project}
- Responsive <picture> element met ondersteuning voor WebP, AVIF en JPG
- Lazy loading toegevoegd voor performance
- Overlay met projecttitel en pijl bij hover
- CSS met kolomlayout en hovertransities

Resolves issue #146 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Ik heb een voorbeeld project gemaakt met meer images (nu staan er namelijk maar 3 project images in directus) hier is het voorbeeld project: 
<img width="357" alt="Scherm­afbeelding 2025-10-23 om 20 45 22" src="https://github.com/user-attachments/assets/1dc8e607-05c5-4376-b724-11c16dd327c1" />
<img width="167"  alt="Scherm­afbeelding 2025-10-23 om 20 45 47" src="https://github.com/user-attachments/assets/e058e376-e03b-4c31-9949-a942ba09bfac" />
<img width="177"  alt="Scherm­afbeelding 2025-10-23 om 20 45 57" src="https://github.com/user-attachments/assets/db14f68c-17c6-4fee-95d5-97106224896b" />



## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [X] [Accessibility test]()
- [X] [Performance test]()
- [X] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<img width="332" height="772" alt="Scherm­afbeelding 2025-10-23 om 21 03 02" src="https://github.com/user-attachments/assets/aaf954ad-064f-41a8-9581-a78b0246274b" />

<img width="292" height="785" alt="Scherm­afbeelding 2025-10-23 om 21 03 16" src="https://github.com/user-attachments/assets/96860ce4-baae-4806-8d8e-af34b02ebe01" />

<img width="516" height="684" alt="Scherm­afbeelding 2025-10-23 om 21 03 41" src="https://github.com/user-attachments/assets/5b100d29-ffcf-4ba0-969d-629a9fbd7318" />


## How to review

Kunnen jullie kijken of hij responsive is in jullie browser en of het er goed uit ziet

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
