### PR TITLE
Feature/newsletter block

### DIFF
--- a/src/lib/components/molecules/NewsletterForm/NewsletterForm.stories.svelte
+++ b/src/lib/components/molecules/NewsletterForm/NewsletterForm.stories.svelte
@@ -1,0 +1,54 @@
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import NewsletterForm from './NewsletterForm.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Molecules/NewsletterForm',
+		component: NewsletterForm,
+		tags: ['autodocs'],
+		parameters: {
+			design: {
+				type: 'figma',
+				url: 'https://www.figma.com/design/doguH52moO2cyA3pT0B6sd/Living-Lab-Bajeskwartier-2025-2026?node-id=3-120&t=IeBjcBYWen78cWmX-1'
+			},
+			docs: {
+				description: {
+					component: `
+
+					`
+				}
+			}
+		}
+	});
+</script>
+
+<Story
+	name="Default"
+	parameters={{
+		// Dit probeert $page te mocken
+		sveltekit_experimental: {
+			stores: {
+				page: {
+					form: null
+				}
+			}
+		}
+	}}
+/>
+
+<Story
+	name="Succes Feedback"
+	parameters={{
+		// Dit probeert $page te mocken
+		sveltekit_experimental: {
+			stores: {
+				page: {
+					form: {
+						success: true,
+						message: 'Bedankt voor je inschrijving!'
+					}
+				}
+			}
+		}
+	}}
+/>

--- a/src/lib/components/molecules/NewsletterForm/NewsletterForm.svelte
+++ b/src/lib/components/molecules/NewsletterForm/NewsletterForm.svelte
@@ -1,19 +1,53 @@
 <script>
-	import NewsletterForm from '$lib/components/molecules/NewsletterForm/NewsletterForm.svelte';
+	import { enhance } from '$app/forms';
+	import { page } from '$app/stores';
 
-	let {
-		title = 'Benieuwd naar nog meer projecten?',
-		description = 'Ontvang onze nieuwsbrief en mis geen enkel update.'
-	} = $props();
+	let loading = $state(false);
+	let showFeedback = $state(false);
+
+	// $effect voor Loading en Feedback state
+	$effect(() => {
+		if ($page.form) {
+			showFeedback = true;
+
+			// Stop loading
+			if ($page.form?.success !== undefined) {
+				setTimeout(() => {
+					loading = false;
+				}, 500);
+			}
+
+			// Hide feedback na 4 seconden
+			setTimeout(() => {
+				showFeedback = false;
+			}, 4000);
+		}
+	});
 </script>
 
-<section class="container">
-	<div class="newsletter-section">
-		<h3>{title}</h3>
-		<p>{description}</p>
-		<NewsletterForm />
-	</div>
-</section>
+<form method="post" use:enhance onsubmit={() => (loading = true)}>
+	<label>
+		<input type="email" name="email" placeholder="vul uw email adres in" required />
+	</label>
+	<button type="submit" disabled={loading}>
+		{#if loading}
+			<span class="loader"></span>
+		{:else}
+			<span>Abboneer</span>
+		{/if}
+	</button>
+</form>
+
+<!-- Als form is gesubmit en feedback is shown, check of form succes is dan show message -->
+<div class="form-status">
+	{#if $page.form && showFeedback}
+		{#if $page.form?.success}
+			<p>{$page.form?.message}</p>
+		{:else}
+			<p>{$page.form?.message} Probeer het opnieuw.</p>
+		{/if}
+	{/if}
+</div>
 
 <style>
 	section {

--- a/src/lib/components/molecules/NewsletterForm/NewsletterForm.svelte
+++ b/src/lib/components/molecules/NewsletterForm/NewsletterForm.svelte
@@ -27,9 +27,8 @@
 
 <div class="form-content-wrapper">
 	<form method="post" use:enhance onsubmit={() => (loading = true)}>
-		<label>
-			<input type="email" name="email" placeholder="vul uw email adres in" required />
-		</label>
+		<label for="email" class="visually-hidden"> E-mailadres </label>
+		<input type="email" name="email" placeholder="vul uw email adres in" required />
 		<button type="submit" disabled={loading}>
 			{#if loading}
 				<span class="loader"></span>
@@ -55,17 +54,17 @@
 	form {
 		display: flex;
 		justify-content: center;
-		margin: 1em 0;
+		margin: var(--spacing-sm) 0;
 		border: none;
 	}
-	form label input {
-		padding: 1em;
+	form input {
+		padding: var(--spacing-sm);
 		border-radius: 7px 0px 0px 7px;
 		border: none;
 		height: 42px;
 	}
 	form button {
-		padding: 1em;
+		padding: var(--spacing-sm);
 		border-radius: 0px 7px 7px 0px;
 		color: var(--color-primary-base);
 		background-color: var(--color-accent2-base);
@@ -87,6 +86,15 @@
 		display: inline-block;
 	}
 
+	.visually-hidden:not(:focus):not(:active) {
+		clip-path: inset(50%);
+		height: 1px;
+		overflow: hidden;
+		position: absolute;
+		white-space: nowrap;
+		width: 1px;
+	}
+
 	@media (min-width: 768px) {
 		form {
 			justify-content: flex-start;
@@ -96,7 +104,7 @@
 		}
 	}
 	@media (min-width: 1024px) {
-		form label input {
+		form input {
 			width: 400px;
 		}
 		form button {

--- a/src/lib/components/molecules/NewsletterForm/NewsletterForm.svelte
+++ b/src/lib/components/molecules/NewsletterForm/NewsletterForm.svelte
@@ -25,57 +25,33 @@
 	});
 </script>
 
-<form method="post" use:enhance onsubmit={() => (loading = true)}>
-	<label>
-		<input type="email" name="email" placeholder="vul uw email adres in" required />
-	</label>
-	<button type="submit" disabled={loading}>
-		{#if loading}
-			<span class="loader"></span>
-		{:else}
-			<span>Abboneer</span>
-		{/if}
-	</button>
-</form>
+<div class="form-content-wrapper">
+	<form method="post" use:enhance onsubmit={() => (loading = true)}>
+		<label>
+			<input type="email" name="email" placeholder="vul uw email adres in" required />
+		</label>
+		<button type="submit" disabled={loading}>
+			{#if loading}
+				<span class="loader"></span>
+			{:else}
+				<span>Abboneer</span>
+			{/if}
+		</button>
+	</form>
 
-<!-- Als form is gesubmit en feedback is shown, check of form succes is dan show message -->
-<div class="form-status">
-	{#if $page.form && showFeedback}
-		{#if $page.form?.success}
-			<p>{$page.form?.message}</p>
-		{:else}
-			<p>{$page.form?.message} Probeer het opnieuw.</p>
+	<!-- Als form is gesubmit en feedback is shown, check of form succes is dan show message -->
+	<div class="form-status">
+		{#if $page.form && showFeedback}
+			{#if $page.form?.success}
+				<p>{$page.form?.message}</p>
+			{:else}
+				<p>{$page.form?.message} Probeer het opnieuw.</p>
+			{/if}
 		{/if}
-	{/if}
+	</div>
 </div>
 
 <style>
-	section {
-		container-type: initial;
-		container-name: Newsletter;
-
-		margin: 2em 1em;
-		padding: 1em;
-		background-color: var(--color-accent2-l3);
-		border-color: var(--color-accent2-base);
-		border-radius: 7px;
-		text-align: center;
-		font-family: 'Urbanist';
-		border: 2px solid var(--color-accent2-base);
-	}
-	section img {
-		width: 150px;
-		height: 150px;
-	}
-
-	/* Newsletter section */
-	h3 {
-		font-size: 32px;
-		font-weight: 700;
-	}
-	.newsletter-section p:first-of-type {
-		margin-top: 1em;
-	}
 	form {
 		display: flex;
 		justify-content: center;
@@ -103,6 +79,8 @@
 
 	/* Form Status */
 	.form-status {
+		display: block;
+		text-align: left;
 		height: 30px;
 	}
 
@@ -111,29 +89,11 @@
 	}
 
 	@media (min-width: 768px) {
-		section {
-			padding: 1em 3em;
-			margin: 2em 1em;
-		}
-		section img {
-			width: 300px;
-			height: 300px;
-		}
-		.newsletter-section {
-			align-content: center;
-			text-align: start;
-		}
-		.newsletter-section p {
-			margin-top: 0.5em;
-		}
 		form {
 			justify-content: flex-start;
 		}
 	}
 	@media (min-width: 1024px) {
-		section {
-			margin: 2em auto;
-		}
 		form label input {
 			width: 400px;
 		}

--- a/src/lib/components/molecules/NewsletterForm/NewsletterForm.svelte
+++ b/src/lib/components/molecules/NewsletterForm/NewsletterForm.svelte
@@ -80,7 +80,6 @@
 	/* Form Status */
 	.form-status {
 		display: block;
-		text-align: left;
 		height: 30px;
 	}
 
@@ -91,6 +90,9 @@
 	@media (min-width: 768px) {
 		form {
 			justify-content: flex-start;
+		}
+		.form-status {
+			text-align: left;
 		}
 	}
 	@media (min-width: 1024px) {

--- a/src/lib/components/molecules/NewsletterForm/NewsletterForm.svelte
+++ b/src/lib/components/molecules/NewsletterForm/NewsletterForm.svelte
@@ -61,7 +61,7 @@
 		padding: var(--spacing-sm);
 		border-radius: 7px 0px 0px 7px;
 		border: none;
-		height: 42px;
+		height: 2.6rem;
 	}
 	form button {
 		padding: var(--spacing-sm);
@@ -73,13 +73,13 @@
 		border: none;
 		cursor: pointer;
 		min-width: max-content;
-		height: 42px;
+		height: 2.6rem;
 	}
 
 	/* Form Status */
 	.form-status {
 		display: block;
-		height: 30px;
+		height: 1.8rem;
 	}
 
 	.loader {

--- a/src/lib/components/organisms/blocks/NewsletterBlock/NewsletterBlock.stories.svelte
+++ b/src/lib/components/organisms/blocks/NewsletterBlock/NewsletterBlock.stories.svelte
@@ -33,63 +33,14 @@
 		title: 'Benieuwd naar nog meer projecten?',
 		description: 'Ontvang onze nieuwsbrief en mis geen enkel update.'
 	}}
-/>
-
-<Story
-	name="With Loading"
-	args={{
-		title: 'Benieuwd naar nog meer projecten?',
-		description: 'Ontvang onze nieuwsbrief en mis geen enkel update.',
-		loading: true
-	}}
 	parameters={{
+		// Dit probeert $page te mocken
 		sveltekit_experimental: {
 			stores: {
 				page: {
 					form: {
-						success: false
-					}
-				}
-			}
-		}
-	}}
-/>
-
-<Story
-	name="With Success Message"
-	args={{
-		title: 'Benieuwd naar nog meer projecten?',
-		description: 'Ontvang onze nieuwsbrief en mis geen enkel update.',
-		showFeedback: true
-	}}
-	parameters={{
-		sveltekit_experimental: {
-			stores: {
-				page: {
-					form: {
-						success: true,
-						message: 'Je bent succesvol ingeschreven!'
-					}
-				}
-			}
-		}
-	}}
-/>
-
-<Story
-	name="With Failed Message"
-	args={{
-		title: 'Benieuwd naar nog meer projecten?',
-		description: 'Ontvang onze nieuwsbrief en mis geen enkel update.',
-		showFeedback: true
-	}}
-	parameters={{
-		sveltekit_experimental: {
-			stores: {
-				page: {
-					form: {
-						success: true,
-						message: 'Mislukt!, Probeer het later nog is.'
+						success: null,
+						message: ''
 					}
 				}
 			}

--- a/src/lib/components/organisms/blocks/NewsletterBlock/NewsletterBlock.stories.svelte
+++ b/src/lib/components/organisms/blocks/NewsletterBlock/NewsletterBlock.stories.svelte
@@ -1,0 +1,98 @@
+<script module>
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import NewsletterBlock from './NewsletterBlock.svelte';
+
+	const { Story } = defineMeta({
+		title: 'Organisms/Blocks/NewsletterBlock',
+		component: NewsletterBlock,
+		tags: ['autodocs'],
+		argTypes: {
+			title: {
+				control: 'text'
+			}
+		},
+		parameters: {
+			design: {
+				type: 'figma',
+				url: 'https://www.figma.com/design/doguH52moO2cyA3pT0B6sd/Living-Lab-Bajeskwartier-2025-2026?node-id=667-1423&t=3ufvBviBPr2YLWJs-1'
+			},
+			// Document text
+			docs: {
+				description: {
+					component: `
+					`
+				}
+			}
+		}
+	});
+</script>
+
+<Story
+	name="NewsletterBlock"
+	args={{
+		title: 'Benieuwd naar nog meer projecten?',
+		description: 'Ontvang onze nieuwsbrief en mis geen enkel update.'
+	}}
+/>
+
+<Story
+	name="With Loading"
+	args={{
+		title: 'Benieuwd naar nog meer projecten?',
+		description: 'Ontvang onze nieuwsbrief en mis geen enkel update.',
+		loading: true
+	}}
+	parameters={{
+		sveltekit_experimental: {
+			stores: {
+				page: {
+					form: {
+						success: false
+					}
+				}
+			}
+		}
+	}}
+/>
+
+<Story
+	name="With Success Message"
+	args={{
+		title: 'Benieuwd naar nog meer projecten?',
+		description: 'Ontvang onze nieuwsbrief en mis geen enkel update.',
+		showFeedback: true
+	}}
+	parameters={{
+		sveltekit_experimental: {
+			stores: {
+				page: {
+					form: {
+						success: true,
+						message: 'Je bent succesvol ingeschreven!'
+					}
+				}
+			}
+		}
+	}}
+/>
+
+<Story
+	name="With Failed Message"
+	args={{
+		title: 'Benieuwd naar nog meer projecten?',
+		description: 'Ontvang onze nieuwsbrief en mis geen enkel update.',
+		showFeedback: true
+	}}
+	parameters={{
+		sveltekit_experimental: {
+			stores: {
+				page: {
+					form: {
+						success: true,
+						message: 'Mislukt!, Probeer het later nog is.'
+					}
+				}
+			}
+		}
+	}}
+/>

--- a/src/lib/components/organisms/blocks/NewsletterBlock/NewsletterBlock.svelte
+++ b/src/lib/components/organisms/blocks/NewsletterBlock/NewsletterBlock.svelte
@@ -11,8 +11,8 @@
 	<div class="newsletter-section">
 		<h3>{title}</h3>
 		<p>{description}</p>
-		<NewsletterForm />
 	</div>
+	<NewsletterForm />
 </section>
 
 <style>
@@ -29,61 +29,20 @@
 		font-family: 'Urbanist';
 		border: 2px solid var(--color-accent2-base);
 	}
-	section img {
-		width: 150px;
-		height: 150px;
-	}
 
 	/* Newsletter section */
 	h3 {
 		font-size: 32px;
 		font-weight: 700;
 	}
-	.newsletter-section p:first-of-type {
-		margin-top: 1em;
-	}
-	form {
-		display: flex;
-		justify-content: center;
-		margin: 1em 0;
-		border: none;
-	}
-	form label input {
-		padding: 1em;
-		border-radius: 7px 0px 0px 7px;
-		border: none;
-		height: 42px;
-	}
-	form button {
-		padding: 1em;
-		border-radius: 0px 7px 7px 0px;
-		color: var(--color-primary-base);
-		background-color: var(--color-accent2-base);
-		font-weight: 700;
-		font-family: 'Urbanist';
-		border: none;
-		cursor: pointer;
-		min-width: max-content;
-		height: 42px;
-	}
-
-	/* Form Status */
-	.form-status {
-		height: 30px;
-	}
-
-	.loader {
-		display: inline-block;
+	.newsletter-section p {
+		margin: 1em 0em;
 	}
 
 	@media (min-width: 768px) {
 		section {
 			padding: 1em 3em;
 			margin: 2em 1em;
-		}
-		section img {
-			width: 300px;
-			height: 300px;
 		}
 		.newsletter-section {
 			align-content: center;
@@ -92,19 +51,15 @@
 		.newsletter-section p {
 			margin-top: 0.5em;
 		}
-		form {
-			justify-content: flex-start;
-		}
 	}
 	@media (min-width: 1024px) {
 		section {
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			justify-content: space-between;
+			gap: 1em;
 			margin: 2em auto;
-		}
-		form label input {
-			width: 400px;
-		}
-		form button {
-			padding: 1em 3em;
 		}
 	}
 </style>

--- a/src/lib/components/organisms/blocks/NewsletterBlock/NewsletterBlock.svelte
+++ b/src/lib/components/organisms/blocks/NewsletterBlock/NewsletterBlock.svelte
@@ -2,36 +2,39 @@
 	import { enhance } from '$app/forms';
 	import { page } from '$app/stores';
 
-	// Loading en showFeedback zit standaard uit
-	let loading = false;
-	let showFeedback = false;
+	let {
+		title = 'Benieuwd naar nog meer projecten?',
+		description = 'Ontvang onze nieuwsbrief en mis geen enkel update.'
+	} = $props();
 
-	// Reset en toon feedback bij nieuwe form submission
-	// Als form gesubmit is zet showFeeback en verwijder na 4 seconden
-	$: if ($page.form) {
-		showFeedback = true;
-		setTimeout(() => {
-			showFeedback = false;
-		}, 4000);
-	}
+	let loading = $state(false);
+	let showFeedback = $state(false);
 
-	// Stop loading
-	$: if ($page.form?.success !== undefined) {
-		setTimeout(() => {
-			loading = false;
-		}, 500);
-	}
+	// $effect voor Loading en Feedback state
+	$effect(() => {
+		if ($page.form) {
+			showFeedback = true;
 
-	export let title = 'Inside informatie?';
-	export let description = 'Ontvang onze nieuwsbrief en mis geen enkel update.';
+			// Stop loading
+			if ($page.form?.success !== undefined) {
+				setTimeout(() => {
+					loading = false;
+				}, 500);
+			}
+
+			// Hide feedback na 4 seconden
+			setTimeout(() => {
+				showFeedback = false;
+			}, 4000);
+		}
+	});
 </script>
 
 <section class="container">
-	<img src="/icons/newsletter-amico-1.svg" alt="Newsletter amico" fetchpriority="high" />
 	<div class="newsletter-section">
 		<h3>{title}</h3>
 		<p>{description}</p>
-		<form method="post" use:enhance on:submit={() => (loading = true)}>
+		<form method="post" use:enhance onsubmit={() => (loading = true)}>
 			<label>
 				<input type="email" name="email" placeholder="vul uw email adres in" required />
 			</label>
@@ -59,7 +62,11 @@
 
 <style>
 	section {
+		container-type: initial;
+		container-name: Newsletter;
+
 		margin: 2em 1em;
+		padding: 1em;
 		background-color: var(--color-accent2-l3);
 		border-color: var(--color-accent2-base);
 		border-radius: 7px;
@@ -116,10 +123,7 @@
 
 	@media (min-width: 768px) {
 		section {
-			display: flex;
-			flex-direction: row-reverse;
-			justify-content: space-between;
-			padding: 0em 3em;
+			padding: 1em 3em;
 			margin: 2em 1em;
 		}
 		section img {

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -47,7 +47,7 @@ export const actions = {
 			if (apiResponse.ok) {
 				return { success: true, message: '✓ Ingeschreven!' };
 			} else {
-				return { success: false, message: 'Mislukt!' };
+				return { success: false, message: 'Mislukt!, Probeer het later nog is.' };
 			}
 		} catch (error) {
 			console.error(error);

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -47,7 +47,7 @@ export const actions = {
 			if (apiResponse.ok) {
 				return { success: true, message: '✓ Ingeschreven!' };
 			} else {
-				return { success: false, message: 'Mislukt!, Probeer het later nog is.' };
+				return { success: false, message: 'Mislukt! Probeer het later nog eens.' };
 			}
 		} catch (error) {
 			console.error(error);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,9 +1,9 @@
 <script>
 	import HeroBlock from '$lib/components/organisms/blocks/HeroBlock.svelte';
 	import Overons from '$lib/components/organisms/blocks/Overons.svelte';
-	import NieuwsbriefBlock from '$lib/components/organisms/blocks/NieuwsbriefBlock.svelte';
+	import NewsletterBlock from '$lib/components/organisms/blocks/NewsletterBlock/NewsletterBlock.svelte';
 	import ThemelinesBlock from '$lib/components/organisms/blocks/ThemelinesBlock/ThemelinesBlock.svelte';
-	import ProjectsBlock from '$lib/components/organisms/blocks/ProjectsBlock.svelte';
+	import ProjectsBlock from '$lib/components/organisms/blocks/ProjectsBlock/ProjectsBlock.svelte';
 
 	export let data; // komt van +page.server.js
 	const { projects, themes } = data;
@@ -30,7 +30,7 @@
 	buttonLink="/projecten"
 	buttonPosition="flex-end"
 />
-<NieuwsbriefBlock
+<NewsletterBlock
 	title="Benieuwd naar nog meer projecten?"
 	description="Abboneer op onze nieuwsbrief om op de hoogte te blijven."
 />


### PR DESCRIPTION
## What does this change?

Resolves issue #209

- Change legacy mode to Runes mode with correct Runes
- NewsletterForm component bewaard in molecules folder
- Een NewsletterForm story met een $page mock
- Image verwijderd voor juiste design


## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [x] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [x] [Browser test]()

## Images

<img width="418" height="299" alt="image" src="https://github.com/user-attachments/assets/6948e33b-cb0a-4c2d-a68d-8d4610065794" />

<img width="1263" height="174" alt="image" src="https://github.com/user-attachments/assets/160782cb-a35c-4b72-9126-dcab14324c34" />


## How to review

- Test op je device of alles responsive en accessible is.
- Check storybook de component te zien zijn.
