### PR TITLE
fix: navigation popover height

### DIFF
--- a/src/lib/components/organisms/layout/Nav.svelte
+++ b/src/lib/components/organisms/layout/Nav.svelte
@@ -1,144 +1,151 @@
 <script>
-// ...
+	// ...
 </script>
 
 <header>
-  <a href="/" class="logo"><span>Healthy Urban</span>Living Lab</a>
-  <button popovertarget="menu" class="menu-toggle" aria-label="Open menu">☰</button>
-  <nav id="menu" popover>
-    <button popovertarget="menu" popovertargetaction="hide" class="menu-close" aria-label="Sluit menu">✕</button>  
-      <ul>
-        <li><a href="/over-ons" class="text">Over ons</a></li>
-        <li><a href="/projecten" class="text">Projecten</a></li>
-        <li><a href="/netwerk" class="text">Netwerk</a></li>
-        <li><a href="/contact" class="text">Contact</a></li>
-      </ul>
-  </nav>
+	<a href="/" class="logo"><span>Healthy Urban</span>Living Lab</a>
+	<button popovertarget="menu" class="menu-toggle" aria-label="Open menu">☰</button>
+	<nav id="menu" popover>
+		<button
+			popovertarget="menu"
+			popovertargetaction="hide"
+			class="menu-close"
+			aria-label="Sluit menu">✕</button
+		>
+		<ul>
+			<li><a href="/over-ons" class="text">Over ons</a></li>
+			<li><a href="/projecten" class="text">Projecten</a></li>
+			<li><a href="/netwerk" class="text">Netwerk</a></li>
+			<li><a href="/contact" class="text">Contact</a></li>
+		</ul>
+	</nav>
 </header>
 
 <style>
-/* ---- HEADER ---- */
-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem clamp(1rem, 4vw, 2rem);
-  background: rgba(255, 255, 255, 0.386);
-  backdrop-filter: blur(10px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, .1);
-}
+	/* ---- HEADER ---- */
+	header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 1rem clamp(1rem, 4vw, 2rem);
+		background: rgba(255, 255, 255, 0.386);
+		backdrop-filter: blur(10px);
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+	}
 
-/* ---- LOGO ---- */
-span {
-  display: block;
-  font-size: 0.8em;
-  line-height: 1.2;
-  letter-spacing: 0.02em;
-  font-weight: 700;
-}
+	/* ---- LOGO ---- */
+	span {
+		display: block;
+		font-size: 0.8em;
+		line-height: 1.2;
+		letter-spacing: 0.02em;
+		font-weight: 700;
+	}
 
-.logo {
-  font-family: "Tilt Warp", sans-serif;
-  font-size: clamp(1.3rem, 1.5vw, 1.125rem);
-  color: var(--color-accent2-d1);
-  line-height: 1.1;
-  white-space: nowrap;
-  font-weight: 400;
-}
+	.logo {
+		font-family: 'Tilt Warp', sans-serif;
+		font-size: clamp(1.3rem, 1.5vw, 1.125rem);
+		color: var(--color-accent2-d1);
+		line-height: 1.1;
+		white-space: nowrap;
+		font-weight: 400;
+	}
 
-/* ---- MOBILE MENU BUTTONS  ---- */
-.menu-toggle,
-.menu-close {
-  font-size: 2rem;
-  color: var(--color-accent2-d1);
-}
+	/* ---- MOBILE MENU BUTTONS  ---- */
+	.menu-toggle,
+	.menu-close {
+		font-size: var(--spacing-md);
+		color: var(--color-accent2-d1);
+	}
 
-.menu-close {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-}
+	.menu-close {
+		position: absolute;
+		top: 1rem;
+		right: 1rem;
+	}
 
-/* ---- POPOVER MENU ---- */
-[popover] {
-  position: fixed;
-  inset: 0;
-  width: 100%;
-  height: min(60dvh, 100%);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border: none;
-  box-shadow: 0 4px 16px rgba(0,0,0,0.15);
-  transform: translateY(-100%);
-  opacity: 0;
-  transition: transform 350ms ease, opacity 200ms ease;
-  pointer-events: none;
-}
+	/* ---- POPOVER MENU ---- */
+	[popover] {
+		position: fixed;
+		inset: 0;
+		width: 100%;
+		height: min(100vh, 100%);
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		border: none;
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+		transform: translateY(-100%);
+		opacity: 0;
+		transition:
+			transform 350ms ease,
+			opacity 200ms ease;
+		pointer-events: none;
+	}
 
-[popover]:popover-open {
-  transform: translateY(0);
-  opacity: 1;
-  pointer-events: auto;
-}
+	[popover]:popover-open {
+		transform: translateY(0);
+		opacity: 1;
+		pointer-events: auto;
+	}
 
-ul {
-  text-align: center;
-  padding: 0;
-  margin: 0;
-}
+	ul {
+		text-align: center;
+		padding: 0;
+		margin: 0;
+	}
 
-li {
-  border-bottom: 2px solid var(--color-accent2-d1);
-}
+	li {
+		border-bottom: 2px solid var(--color-accent2-d1);
+	}
 
-a {
-  display: block;
-  padding: 1rem;
-  color: var(--color-accent2-d1);
-  font-size: 1.2rem;
-}
+	a {
+		display: block;
+		padding: 1rem;
+		color: var(--color-accent2-d1);
+		font-size: 1.2rem;
+	}
 
-/* ---- DESKTOP MENU ---- */
+	/* ---- DESKTOP MENU ---- */
 
-@media (min-width: 960px) {
-  .menu-toggle,
-  .menu-close {
-    display: none;
-  }
+	@media (min-width: 960px) {
+		.menu-toggle,
+		.menu-close {
+			display: none;
+		}
 
-  [popover] {
-    position: static;
-    transform: none;
-    opacity: 1;
-    pointer-events: auto;
-    background: none;
-    border: none;
-    box-shadow: none;
-    height: auto;
-    display: flex;
-    justify-content: space-evenly;
-    align-items: center;
-    gap: 2rem;
-  }
+		[popover] {
+			position: static;
+			transform: none;
+			opacity: 1;
+			pointer-events: auto;
+			background: none;
+			border: none;
+			box-shadow: none;
+			height: auto;
+			display: flex;
+			justify-content: flex-end;
+			align-items: center;
+			gap: var(--spacing-md);
+		}
 
-  ul {
-    display: flex;
-    justify-content: flex-end;
-    gap: 2rem;
-  }
+		ul {
+			display: flex;
+			justify-content: flex-end;
+			gap: var(--spacing-lg);
+		}
 
-  li {
-    border: none;
-  }
+		li {
+			border: none;
+		}
 
-  a {
-    color: black;
-  }
+		a {
+			color: black;
+		}
 
-  #menu a:hover {
-      color: var(--color-accent2-d1);
-      text-decoration: underline;
-    }
-}
+		#menu a:hover {
+			color: var(--color-accent2-d1);
+			text-decoration: underline;
+		}
+	}
 </style>

--- a/src/lib/components/organisms/layout/Nav.svelte
+++ b/src/lib/components/organisms/layout/Nav.svelte
@@ -1,10 +1,31 @@
 <script>
-	import { browser } from '$app/environment'; // Belangrijk voor SvelteKit
+	import { browser } from '$app/environment';
 
-	let { isOpen } = $props(); // Of je eigen variabele die bijhoudt of het menu open is
+	// Variabele om het menu element op te slaan
+	let menuElement;
 
+	// State die bijhoudt of het menu open of gesloten is
+	let isOpen = $state(false);
+
+	// Effect 1: Luistert naar wanneer het popover menu open/dicht gaat
+	// en update de isOpen state
 	$effect(() => {
-		// Check of we in de browser zijn om 'document is not defined' errors te voorkomen
+		if (!browser || !menuElement) return;
+
+		const handleToggle = (event) => {
+			isOpen = event.newState === 'open';
+		};
+
+		menuElement.addEventListener('toggle', handleToggle);
+
+		return () => {
+			menuElement?.removeEventListener('toggle', handleToggle);
+		};
+	});
+
+	// Effect 2: Als het menu open is, blokkeer dan scrollen op de body
+	// Als het menu dicht is, sta scrollen weer toe
+	$effect(() => {
 		if (!browser) return;
 
 		if (isOpen) {
@@ -13,7 +34,6 @@
 			document.body.style.overflow = 'auto';
 		}
 
-		// Cleanup: herstel scroll als de component wordt afgesloten
 		return () => {
 			if (browser) document.body.style.overflow = 'auto';
 		};
@@ -23,7 +43,7 @@
 <header>
 	<a href="/" class="logo"><span>Healthy Urban</span>Living Lab</a>
 	<button popovertarget="menu" class="menu-toggle" aria-label="Open menu">☰</button>
-	<nav id="menu" popover>
+	<nav id="menu" popover bind:this={menuElement}>
 		<button
 			popovertarget="menu"
 			popovertargetaction="hide"
@@ -101,6 +121,10 @@
 			display 350ms allow-discrete,
 			overlay 350ms allow-discrete;
 		pointer-events: none;
+
+		/* Voeg dit toe: */
+		overscroll-behavior: contain;
+		overflow: hidden;
 	}
 
 	[popover]:popover-open {

--- a/src/lib/components/organisms/layout/Nav.svelte
+++ b/src/lib/components/organisms/layout/Nav.svelte
@@ -1,5 +1,23 @@
 <script>
-	// ...
+	import { browser } from '$app/environment'; // Belangrijk voor SvelteKit
+
+	let { isOpen } = $props(); // Of je eigen variabele die bijhoudt of het menu open is
+
+	$effect(() => {
+		// Check of we in de browser zijn om 'document is not defined' errors te voorkomen
+		if (!browser) return;
+
+		if (isOpen) {
+			document.body.style.overflow = 'hidden';
+		} else {
+			document.body.style.overflow = 'auto';
+		}
+
+		// Cleanup: herstel scroll als de component wordt afgesloten
+		return () => {
+			if (browser) document.body.style.overflow = 'auto';
+		};
+	});
 </script>
 
 <header>
@@ -79,7 +97,9 @@
 		opacity: 0;
 		transition:
 			transform 350ms ease,
-			opacity 200ms ease;
+			opacity 350ms ease,
+			display 350ms allow-discrete,
+			overlay 350ms allow-discrete;
 		pointer-events: none;
 	}
 
@@ -87,6 +107,14 @@
 		transform: translateY(0);
 		opacity: 1;
 		pointer-events: auto;
+	}
+
+	/* Start positie van de opening animatie */
+	@starting-style {
+		[popover]:popover-open {
+			transform: translateY(-100%);
+			opacity: 0;
+		}
 	}
 
 	ul {

--- a/src/lib/components/organisms/layout/Nav.svelte
+++ b/src/lib/components/organisms/layout/Nav.svelte
@@ -113,7 +113,6 @@
 		align-items: center;
 		border: none;
 		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-		transform: translateY(-100%);
 		opacity: 0;
 		transition:
 			transform 350ms ease,
@@ -121,8 +120,6 @@
 			display 350ms allow-discrete,
 			overlay 350ms allow-discrete;
 		pointer-events: none;
-
-		/* Voeg dit toe: */
 		overscroll-behavior: contain;
 		overflow: hidden;
 	}
@@ -136,7 +133,6 @@
 	/* Start positie van de opening animatie */
 	@starting-style {
 		[popover]:popover-open {
-			transform: translateY(-100%);
 			opacity: 0;
 		}
 	}


### PR DESCRIPTION
## What does this change?

Resolves issue #107

- Popover height toont nu volle scherm op mobile

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [x] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<img width="1140" height="158" alt="image" src="https://github.com/user-attachments/assets/c4614aa4-7f99-4c52-975f-ef8d2b097528" />


<img width="468" height="808" alt="image" src="https://github.com/user-attachments/assets/82220d5e-f3db-4181-b853-577b28146a58" />


## How to review

Check of de navigatie is gefixed op je browser