### PR TITLE
Feature/themelines-animation

### DIFF
--- a/src/lib/components/organisms/blocks/ThemelinesBlock/ThemelinesBlock.svelte
+++ b/src/lib/components/organisms/blocks/ThemelinesBlock/ThemelinesBlock.svelte
@@ -39,7 +39,7 @@
 				opacity: 0,
 				y: 50,
 				duration: 0.8,
-				stagger: 0.3,
+				stagger: 0.4,
 				scrollTrigger: {
 					trigger: cardsContainer,
 					start: 'top 80%'

--- a/src/lib/components/organisms/blocks/ThemelinesBlock/ThemelinesBlock.svelte
+++ b/src/lib/components/organisms/blocks/ThemelinesBlock/ThemelinesBlock.svelte
@@ -1,4 +1,10 @@
 <script>
+	import { onMount } from 'svelte';
+
+	import { browser } from '$app/environment';
+	import gsap from 'gsap';
+	import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
 	export let themes = [];
 	export let title = 'Themalijnen';
 	export let showIntro = false;
@@ -13,11 +19,39 @@
 	export let buttonText = 'Lees meer';
 	export let buttonLink = '/over-ons#theme-line';
 	export let buttonPosition = 'center';
+
+	let titleElement;
+	let cardsContainer;
+
+	onMount(async () => {
+		if (browser) {
+			gsap.registerPlugin(ScrollTrigger);
+
+			gsap.from(titleElement, {
+				opacity: 0,
+				y: 50,
+				duration: 1,
+				scrollTrigger: titleElement,
+				start: 'bottom 10%'
+			});
+
+			gsap.from(cardsContainer.children, {
+				opacity: 0,
+				y: 50,
+				duration: 0.8,
+				stagger: 0.3,
+				scrollTrigger: {
+					trigger: cardsContainer,
+					start: 'top 80%'
+				}
+			});
+		}
+	});
 </script>
 
 <section class="container">
-	<h2 class="title">{title}</h2>
-	<ul class="{layout}-layout">
+	<h2 class="title" bind:this={titleElement}>{title}</h2>
+	<ul class="{layout}-layout" bind:this={cardsContainer}>
 		{#each themes as theme}
 			<ThemeCard {theme} {layout} {showIntro} />
 		{/each}

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -9,7 +9,7 @@ export async function load({ fetch }) {
 			const projects = await projectReq.json();
 			const themes = await themeReq.json();
 
-			console.log(themes.data);
+			// console.log(themes.data);
 			return {
 				projects: projects.data,
 				themes: themes.data


### PR DESCRIPTION
## What does this change?

Resolves issue #226

- GSAP ScrollTrigger animatie toegevoegd aan ThemelinesBlock
- Fade-in animatie met y-offset (50px) voor cards
- Stagger effect (0.4s) tussen de cards

## How Has This Been Tested?

- [ ] [User test]()
- [x] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

https://github.com/user-attachments/assets/c91c0a24-7326-454f-9ddd-39caa6db792f

## How to review

Check of het animatie werkt op safari.