### PR TITLE
feat: GSAP animations respect reduced motion +  add a aria labelled by on project link

### DIFF
--- a/src/lib/components/molecules/ProjectCard/ProjectCard.svelte
+++ b/src/lib/components/molecules/ProjectCard/ProjectCard.svelte
@@ -66,9 +66,9 @@
     </picture>
   </div>
   
-  <h2 class="subtitle">{project.title}</h2>
+  <h2 id={project.title} class="subtitle">{project.title}</h2>
   <p class="text">{@html project.description}</p>
-  <a href={`/projecten/${project.slug}`} class="project-link">
+  <a href={`/projecten/${project.slug}`} class="project-link" aria-labelledby={project.title} >
     Bekijk het project
     <span class="arrow-container">
       <ArrowIcon className="project-arrow" />

--- a/src/lib/components/molecules/ProjectCard/ProjectCard.svelte
+++ b/src/lib/components/molecules/ProjectCard/ProjectCard.svelte
@@ -1,51 +1,59 @@
 <script>
-  import { onMount } from 'svelte';
-  import ArrowIcon from '$lib/components/atoms/icons/ArrowIcon.svelte'
-  
-  let {
-    project,
-    ASSETS_URL = "https://fdnd-agency.directus.app/assets"
-  } = $props();
+import { onMount } from 'svelte';
+import { browser } from '$app/environment';
+import ArrowIcon from '$lib/components/atoms/icons/ArrowIcon.svelte'
+import { gsap } from '$lib/gsap-config'; 
 
-  // foto inlaad animatie met gsap
-  let pictureElement;
-  let imageContainer;
+let {
+  project,
+  ASSETS_URL = "https://fdnd-agency.directus.app/assets"
+} = $props();
 
-  onMount(async () => {
-    const { gsap } = await import('gsap');
-    const { ScrollTrigger } = await import('gsap/ScrollTrigger');
+let pictureElement;
+let imageContainer;
+
+onMount(async () => {
+  if (browser) {
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     
-    gsap.registerPlugin(ScrollTrigger);
-    
-    const img = imageContainer.querySelector('img');
-    
-    const startAnimation = () => {
-      gsap.fromTo(
-        pictureElement,
-        { clipPath: 'inset(100% 100% 0% 0%)' },
-        {
-          clipPath: 'inset(0% 0% 0% 0%)',
-          duration: 1.2,
-          ease: 'power4.out',
-          delay: 0.1,
-          scrollTrigger: {
-            trigger: imageContainer,
-            start: 'top 90%',
-            once: true
+    if (!prefersReducedMotion) {
+      // Alleen animeren als reduced motion UIT staat
+      const { ScrollTrigger } = await import('gsap/ScrollTrigger');
+      gsap.registerPlugin(ScrollTrigger);
+      
+      const img = imageContainer.querySelector('img');
+      
+      const startAnimation = () => {
+        gsap.fromTo(
+          pictureElement,
+          { clipPath: 'inset(100% 100% 0% 0%)' },
+          {
+            clipPath: 'inset(0% 0% 0% 0%)',
+            duration: 1.2,
+            ease: 'power4.out',
+            delay: 0.1,
+            scrollTrigger: {
+              trigger: imageContainer,
+              start: 'top 90%',
+              once: true
+            }
           }
+        );
+      };
+      
+      if (img) {
+        if (img.complete) {
+          startAnimation();
+        } else {
+          img.addEventListener('load', startAnimation);
         }
-      );
-    };
-    
-    // kijken of de afbeelding al geladen is
-    if (img) {
-      if (img.complete) {
-        startAnimation();
-      } else {
-        img.addEventListener('load', startAnimation);
       }
+    } else {
+      // Bij reduced motion: verwijder clipPath zodat afbeelding zichtbaar is
+      gsap.set(pictureElement, { clipPath: 'inset(0% 0% 0% 0%)' });
     }
-  });
+  }
+});
 </script>
 
 <section class="project-card">

--- a/src/lib/components/organisms/blocks/AboutBlock/AboutBlock.svelte
+++ b/src/lib/components/organisms/blocks/AboutBlock/AboutBlock.svelte
@@ -1,59 +1,59 @@
 <script>
-	import { onMount } from 'svelte';
-	import { browser } from '$app/environment';
-
-	import Button from '$lib/components/atoms/Button/Button.svelte';
-
-	let {
-		title = 'Over ons',
-		description = 'In de voormalige Bijlmer Bajes werken gebiedsontwikkelaar AM, de HvA en verschillende partners sinds 2018 samen in het Healthy Urban Living Lab Bajeskwartier. Het doel is een groene, gezonde en inclusieve buurt voor alle bewoners. Onderzoekers en studenten bekijken samen met bewoners en gebruikers hoe het gebied zo ingericht kan worden dat het bewegen en ontmoeten stimuleert. Dit is belangrijk voor gezondheid en welzijn. Sinds 2023 bevindt de ontwikkeling van het Bajeskwartier zich in een nieuwe fase. De eerste gebouwen zijn opgeleverd, en uiteindelijk komen er 2.500 tot 3.500 mensen te wonen, verdeeld over 1.350 appartementen (huur en koop). De sociale huurwoningen bieden plek aan een diverse groep bewoners: studenten, ouderen, statushouders en mensen die extra begeleiding nodig hebben vanwege sociale of psychische problemen. Daarnaast zijn de middelbare school Spinoza 21st en Hotel Jansen, een verblijf voor internationale studenten en expats, in de wijk gevestigd.',
-		variant = 'full',
-		image = '/images/over-ons.png',
-		videoSrc = '/videos/about.mp4',
-		showButton = false,
-		buttonLink = '/over-ons'
-	} = $props();
-
-	// Deze functie draait server-side én client-side
-	function truncateText(text, wordLimit = 65) {
-		if (!text) return '';
-		const plainText = text.replace(/<[^>]*>/g, '');
-		const words = plainText.split(' ');
-		if (words.length <= wordLimit) return text;
-		return words.slice(0, wordLimit).join(' ') + '...';
-	}
-
-	// $derived: Toont korte tekst bij 'preview', volledige tekst bij 'full'
-	const displayDescription = $derived(
-		variant === 'preview' ? truncateText(description, 65) : description
-	);
-
-	let titleElement;
-
-	onMount(async () => {
-		if (browser) {
-			const { gsap } = await import('gsap');
-			const { SplitText } = await import('gsap/SplitText');
-			const { ScrollTrigger } = await import('gsap/ScrollTrigger');
-
-			gsap.registerPlugin(ScrollTrigger);
-			gsap.registerPlugin(SplitText);
-
-			// We splitsen de tekst in karakters
-			const split = new SplitText(titleElement, { type: 'chars' });
-
-			gsap.from(split.chars, {
-				y: '100%', // Start precies onder de regel
-				opacity: 0, // Subtiele fade-in erbij
-				duration: 1.2, // Iets langer voor een rustig gevoel
-				scrollTrigger: titleElement,
-				start: 'bottom 10%',
-				stagger: 0.03, // Heel kort achter elkaar voor een vloeiende beweging
-				ease: 'power4.out', // De meest 'high-end' easing (start vlot, eindigt heel traag)
-				delay: 0.1
-			});
-		}
-	});
+    import { onMount } from 'svelte';
+    import { browser } from '$app/environment';
+    import { gsap } from '$lib/gsap-config'; 
+    import Button from '$lib/components/atoms/Button/Button.svelte';
+    
+    let {
+        title = 'Over ons',
+        description = '...',
+        variant = 'full',
+        image = '/images/over-ons.png',
+        videoSrc = '/videos/about.mp4',
+        showButton = false,
+        buttonLink = '/over-ons'
+    } = $props();
+    
+    function truncateText(text, wordLimit = 65) {
+        if (!text) return '';
+        const plainText = text.replace(/<[^>]*>/g, '');
+        const words = plainText.split(' ');
+        if (words.length <= wordLimit) return text;
+        return words.slice(0, wordLimit).join(' ') + '...';
+    }
+    
+    const displayDescription = $derived(
+        variant === 'preview' ? truncateText(description, 65) : description
+    );
+    
+    let titleElement;
+    
+    onMount(async () => {
+        if (browser) {
+            const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            
+            if (!prefersReducedMotion) {
+                const { SplitText } = await import('gsap/SplitText');
+                const { ScrollTrigger } = await import('gsap/ScrollTrigger');
+                gsap.registerPlugin(SplitText);
+                gsap.registerPlugin(ScrollTrigger);
+                
+                const split = new SplitText(titleElement, { type: 'chars' });
+                gsap.from(split.chars, {
+                    y: '100%',
+                    opacity: 0,
+                    duration: 1.2,
+                    stagger: 0.03,
+                    ease: 'power4.out',
+                    delay: 0.1,
+                    scrollTrigger: {
+                        trigger: titleElement,
+                        start: 'top 80%'
+                    }
+                });
+            }
+        }
+    });
 </script>
 
 <section class="container">

--- a/src/lib/components/organisms/blocks/NewsletterBlock/NewsletterBlock.svelte
+++ b/src/lib/components/organisms/blocks/NewsletterBlock/NewsletterBlock.svelte
@@ -2,8 +2,8 @@
     import NewsletterForm from '$lib/components/molecules/NewsletterForm/NewsletterForm.svelte';
 
     let {
-        title = 'Benieuwd naar nog meer projecten?'
-		, description = 'Schrijf je in voor onze nieuwsbrief en blijf op de hoogte van het laatste nieuws en updates.'
+        title = 'Benieuwd naar nog meer projecten?', 
+        description = 'Schrijf je in voor onze nieuwsbrief en blijf op de hoogte van het laatste nieuws en updates.'
     } = $props();
 </script>
 

--- a/src/lib/components/organisms/blocks/ProjectsBlock/ProjectsBlock.svelte
+++ b/src/lib/components/organisms/blocks/ProjectsBlock/ProjectsBlock.svelte
@@ -1,47 +1,48 @@
 <script>
-	import { onMount } from 'svelte';
-	import { browser } from '$app/environment';
-
-	import ProjectCard from '$lib/components/molecules/ProjectCard/ProjectCard.svelte';
-	import Button from '$lib/components/atoms/Button/Button.svelte';
-
-	let {
-		ASSETS_URL = 'https://fdnd-agency.directus.app/assets',
-		projects = [],
-		title = 'Projecten',
-		buttonText = 'Bekijk alle projecten',
-		buttonLink = '/projecten',
-		buttonPosition = 'flex-end'
-	} = $props();
-
-	let highlightedProjects = $derived(projects.filter((project) => project.highlighted === true));
-
-	let titleElement;
-
-	onMount(async () => {
-		if (browser) {
-			const { gsap } = await import('gsap');
-			const { SplitText } = await import('gsap/SplitText');
-			const { ScrollTrigger } = await import('gsap/ScrollTrigger');
-
-			gsap.registerPlugin(ScrollTrigger);
-			gsap.registerPlugin(SplitText);
-
-			// We splitsen de tekst in karakters
-			const split = new SplitText(titleElement, { type: 'chars' });
-
-			gsap.from(split.chars, {
-				y: '100%', // Start precies onder de regel
-				opacity: 0, // Subtiele fade-in erbij
-				duration: 1.2, // Iets langer voor een rustig gevoel
-				scrollTrigger: titleElement,
-				start: 'bottom 10%',
-				stagger: 0.03, // Heel kort achter elkaar voor een vloeiende beweging
-				ease: 'power4.out', // De meest 'high-end' easing (start vlot, eindigt heel traag)
-				delay: 0.1
-			});
-		}
-	});
+    import { onMount } from 'svelte';
+    import { browser } from '$app/environment';
+    import { gsap } from '$lib/gsap-config'; 
+    import ProjectCard from '$lib/components/molecules/ProjectCard/ProjectCard.svelte';
+    import Button from '$lib/components/atoms/Button/Button.svelte';
+    
+    let {
+        ASSETS_URL = 'https://fdnd-agency.directus.app/assets',
+        projects = [],
+        title = 'Projecten',
+        buttonText = 'Bekijk alle projecten',
+        buttonLink = '/projecten',
+        buttonPosition = 'flex-end'
+    } = $props();
+    
+    let highlightedProjects = $derived(projects.filter((project) => project.highlighted === true));
+    let titleElement;
+    
+    onMount(async () => {
+        if (browser) {
+            const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            
+            if (!prefersReducedMotion) {
+                const { SplitText } = await import('gsap/SplitText');
+                const { ScrollTrigger } = await import('gsap/ScrollTrigger');
+                gsap.registerPlugin(SplitText);
+                gsap.registerPlugin(ScrollTrigger);
+                
+                const split = new SplitText(titleElement, { type: 'chars' });
+                gsap.from(split.chars, {
+                    y: '100%',
+                    opacity: 0,
+                    duration: 1.2,
+                    stagger: 0.03,
+                    ease: 'power4.out',
+                    delay: 0.1,
+                    scrollTrigger: {
+                        trigger: titleElement,
+                        start: 'top 80%'
+                    }
+                });
+            }
+        }
+    });
 </script>
 
 <section class="container">

--- a/src/lib/components/organisms/blocks/TeamBlock/TeamBlock.svelte
+++ b/src/lib/components/organisms/blocks/TeamBlock/TeamBlock.svelte
@@ -1,39 +1,42 @@
 <script>
-  import { onMount } from 'svelte';
-	import { browser } from '$app/environment';
-  import NetwerkCard from '$lib/components/molecules/NetwerkCard/NetwerkCard.svelte';
+    import { onMount } from 'svelte';
+    import { browser } from '$app/environment';
+    import { gsap } from '$lib/gsap-config'; 
+    import NetwerkCard from '$lib/components/molecules/NetwerkCard/NetwerkCard.svelte';
     
-  let { 
-    title = 'Ons team',
-    people = []
-  } = $props();
-
-  let titleElement;
-
-  onMount(async () => {
-		if (browser) {
-			const { gsap } = await import('gsap');
-			const { SplitText } = await import('gsap/SplitText');
-			const { ScrollTrigger } = await import('gsap/ScrollTrigger');
-
-			gsap.registerPlugin(ScrollTrigger);
-			gsap.registerPlugin(SplitText);
-
-			// We splitsen de tekst in karakters
-			const split = new SplitText(titleElement, { type: 'chars' });
-
-			gsap.from(split.chars, {
-				y: '100%', // Start precies onder de regel
-				opacity: 0, // Subtiele fade-in erbij
-				duration: 1.2, // Iets langer voor een rustig gevoel
-				scrollTrigger: titleElement,
-				start: 'bottom 10%',
-				stagger: 0.03, // Heel kort achter elkaar voor een vloeiende beweging
-				ease: 'power4.out', // De meest 'high-end' easing (start vlot, eindigt heel traag)
-				delay: 0.1
-			});
-		}
-	});
+    let { 
+        title = 'Ons team',
+        people = []
+    } = $props();
+    
+    let titleElement;
+    
+    onMount(async () => {
+        if (browser) {
+            const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            
+            if (!prefersReducedMotion) {
+                const { SplitText } = await import('gsap/SplitText');
+                const { ScrollTrigger } = await import('gsap/ScrollTrigger');
+                gsap.registerPlugin(SplitText);
+                gsap.registerPlugin(ScrollTrigger);
+                
+                const split = new SplitText(titleElement, { type: 'chars' });
+                gsap.from(split.chars, {
+                    y: '100%',
+                    opacity: 0,
+                    duration: 1.2,
+                    stagger: 0.03,
+                    ease: 'power4.out',
+                    delay: 0.1,
+                    scrollTrigger: {
+                        trigger: titleElement,
+                        start: 'top 80%'
+                    }
+                });
+            }
+        }
+    });
 </script>
   
 <section class="container">

--- a/src/lib/components/organisms/blocks/ThemelinesBlock/ThemelinesBlock.svelte
+++ b/src/lib/components/organisms/blocks/ThemelinesBlock/ThemelinesBlock.svelte
@@ -1,60 +1,64 @@
 <script>
-	import { onMount } from 'svelte';
-	import { browser } from '$app/environment';
-
-	export let themes = [];
-	export let title = 'Themalijnen';
-	export let showIntro = false;
-	export let layout = 'row';
-
-	const ASSETS_URL = 'https://fdnd-agency.directus.app/assets';
-
 	import Button from '$lib/components/atoms/Button/Button.svelte';
-	import ThemeCard from '$lib/components/molecules/ThemeCard/ThemeCard.svelte';
+    import ThemeCard from '$lib/components/molecules/ThemeCard/ThemeCard.svelte';
+    import { onMount } from 'svelte';
+    import { browser } from '$app/environment';
+    import { gsap } from '$lib/gsap-config'; 
 
-	export let showButton = true;
-	export let buttonText = 'Lees meer';
-	export let buttonLink = '/over-ons#theme-line';
-	export let buttonPosition = 'center';
-
-	let titleElement;
-	let cardsContainer;
-
-	onMount(async () => {
-		if (browser) {
-			const { gsap } = await import('gsap');
-			const { SplitText } = await import('gsap/SplitText');
-			const { ScrollTrigger } = await import('gsap/ScrollTrigger');
-
-			gsap.registerPlugin(ScrollTrigger);
-			gsap.registerPlugin(SplitText);
-
-			// We splitsen de tekst in karakters
-			const split = new SplitText(titleElement, { type: 'chars' });
-
-			gsap.from(split.chars, {
-				y: '100%', // Start precies onder de regel
-				opacity: 0, // Subtiele fade-in erbij
-				duration: 1.2, // Iets langer voor een rustig gevoel
-				scrollTrigger: titleElement,
-				start: 'bottom 10%',
-				stagger: 0.03, // Heel kort achter elkaar voor een vloeiende beweging
-				ease: 'power4.out', // De meest 'high-end' easing (start vlot, eindigt heel traag)
-				delay: 0.1
-			});
-
-			gsap.from(cardsContainer.children, {
-				opacity: 0,
-				y: 50,
-				duration: 0.8,
-				stagger: 0.4,
-				scrollTrigger: {
-					trigger: cardsContainer,
-					start: 'top 80%'
-				}
-			});
-		}
-	});
+    
+	let { 
+		themes = [],
+		title = 'Themalijnen',
+		showIntro = false,
+		layout = 'row',
+		showButton = true,
+		buttonText = 'Lees meer',
+		buttonLink = '/over-ons#theme-line',
+		buttonPosition = 'center'	
+	} = $props();
+   
+    const ASSETS_URL = 'https://fdnd-agency.directus.app/assets';
+    
+    let cardsContainer;
+    let titleElement;
+    
+    onMount(async () => {
+        if (browser) {
+            const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            
+            if (!prefersReducedMotion) {
+                const { SplitText } = await import('gsap/SplitText');
+                const { ScrollTrigger } = await import('gsap/ScrollTrigger');
+                gsap.registerPlugin(ScrollTrigger);
+                gsap.registerPlugin(SplitText);
+                
+                const split = new SplitText(titleElement, { type: 'chars' });
+                gsap.from(split.chars, {
+                    y: '100%',
+                    opacity: 0,
+                    duration: 1.2,
+                    stagger: 0.03,
+                    ease: 'power4.out',
+                    delay: 0.1,
+                    scrollTrigger: {
+                        trigger: titleElement,
+                        start: 'top 80%'
+                    }
+                });
+                
+                gsap.from(cardsContainer.children, {
+                    opacity: 0,
+                    y: 50,
+                    duration: 0.8,
+                    stagger: 0.4,
+                    scrollTrigger: {
+                        trigger: cardsContainer,
+                        start: 'top 80%'
+                    }
+                });
+            }
+        }
+    });
 </script>
 
 <section class="container">

--- a/src/lib/gsap-config.js
+++ b/src/lib/gsap-config.js
@@ -1,0 +1,5 @@
+import { gsap } from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+import { browser } from '$app/environment';
+
+export { gsap, ScrollTrigger };

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -1,32 +1,35 @@
 <script>
-	import { onMount } from 'svelte';
-	import { browser } from '$app/environment';
+import { onMount } from 'svelte';
+import { browser } from '$app/environment';
+import ContactCard from '$lib/components/molecules/ContactCard/ContactCard.svelte';
+import { gsap } from '$lib/gsap-config';
 
-	import ContactCard from '$lib/components/molecules/ContactCard/ContactCard.svelte';
-	let { title = 'Contact', data } = $props();
+let { title = 'Contact', data } = $props();
 
-	let titleElement;
+let titleElement;
 
-	onMount(async () => {
-		if (browser) {
-			const { gsap } = await import('gsap');
-			const { SplitText } = await import('gsap/SplitText');
-
-			gsap.registerPlugin(SplitText);
-
-			// We splitsen de tekst in karakters
-			const split = new SplitText(titleElement, { type: 'chars' });
-
-			gsap.from(split.chars, {
-				y: '100%', // Start precies onder de regel
-				opacity: 0, // Subtiele fade-in erbij
-				duration: 1.2, // Iets langer voor een rustig gevoel
-				stagger: 0.03, // Heel kort achter elkaar voor een vloeiende beweging
-				ease: 'power4.out', // De meest 'high-end' easing (start vlot, eindigt heel traag)
-				delay: 0.1
-			});
-		}
-	});
+onMount(async () => {
+  if (browser) {
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    
+    if (!prefersReducedMotion) {
+      // Alleen animeren als reduced motion UIT staat
+      const { SplitText } = await import('gsap/SplitText');
+      gsap.registerPlugin(SplitText);
+      
+      const split = new SplitText(titleElement, { type: 'chars' });
+      gsap.from(split.chars, {
+        y: '100%',
+        opacity: 0,
+        duration: 1.2,
+        stagger: 0.03,
+        ease: 'power4.out',
+        delay: 0.1
+      });
+    }
+    // Bij reduced motion: doe niks, tekst is gewoon zichtbaar
+  }
+});
 </script>
 
 <section class="container">

--- a/src/routes/netwerk/+page.svelte
+++ b/src/routes/netwerk/+page.svelte
@@ -1,113 +1,126 @@
 <script>
-	import { onMount } from 'svelte';
-	import { browser } from '$app/environment';
-
-	import NetwerkCard from '$lib/components/molecules/NetwerkCard/NetwerkCard.svelte';
-
-	// Props van parent component
-	let { title = 'Netwerk', data } = $props();
-
-	// Referentie naar het grid element in de DOM
-	let gridRef;
-	let titleElement;
-
-	// Lifecycle hook: wordt uitgevoerd na component mount
-	onMount(async () => {
-		if (browser) {
-			// Importeer GSAP en ScrollTrigger dynamisch (code splitting)
-			const { gsap } = await import('gsap');
-			const { ScrollTrigger } = await import('gsap/ScrollTrigger');
-			const { SplitText } = await import('gsap/SplitText');
-
-			// Registreer ScrollTrigger plugin bij GSAP
-			gsap.registerPlugin(ScrollTrigger);
-			gsap.registerPlugin(SplitText);
-
-			// Functie die de scroll animaties toepast
-			const applyAnimations = () => {
-				// Verwijder alle bestaande ScrollTriggers om duplicaten te voorkomen
-				ScrollTrigger.getAll().forEach((trigger) => trigger.kill());
-
-				// Stop als gridRef nog niet bestaat
-				if (!gridRef) return;
-
-				// Bepaal hoeveel kolommen het grid heeft
-				const columnCount = window
-					.getComputedStyle(gridRef)
-					.getPropertyValue('grid-template-columns')
-					.split(' ').length; // Tel aantal kolommen
-
-				// Selecteer alle cards
-				const allCards = gridRef.querySelectorAll('.card-wrapper');
-				const split = new SplitText(titleElement, { type: 'chars' });
-
-				// Als er 4 of meer kolommen zijn, pas effect toe
-				if (columnCount >= 4) {
-					// Selecteer alle cards in kolom 1 (1e, 5e, 9e, etc.)
-					const column1Cards = gridRef.querySelectorAll('.card-wrapper:nth-child(4n+1)');
-					// Selecteer alle cards in kolom 3 (3e, 7e, 11e, etc.)
-					const column3Cards = gridRef.querySelectorAll('.card-wrapper:nth-child(4n+3)');
-
-					// Zet CSS class voor styling
-					allCards.forEach((card) => card.classList.remove('no-offset'));
-					column1Cards.forEach((card) => card.classList.add('offset'));
-					column3Cards.forEach((card) => card.classList.add('offset'));
-
-					// Timeline voor beide kolommen
-					const tl = gsap.timeline({
-						scrollTrigger: {
-							trigger: gridRef,
-							start: 'top bottom',
-							end: 'bottom top',
-							scrub: true
-						}
-					});
-
-					// Animeer van CSS positie (250px) naar -250px
-					tl.to(
-						[column1Cards, column3Cards],
-						{
-							y: -250,
-							ease: 'none',
-							overwrite: 'auto'
-						},
-						0
-					);
-				} else {
-					// Bij minder dan 4 kolommen: verwijder offset class en reset
-					allCards.forEach((card) => {
-						card.classList.remove('offset');
-						card.classList.add('no-offset');
-					});
-					gsap.set(allCards, { clearProps: 'all' });
-				}
-
-				gsap.from(split.chars, {
-					y: '100%', // Start precies onder de regel
-					opacity: 0, // Subtiele fade-in erbij
-					duration: 1.2, // Iets langer voor een rustig gevoel
-					stagger: 0.03, // Heel kort achter elkaar voor een vloeiende beweging
-					ease: 'power4.out', // De meest 'high-end' easing (start vlot, eindigt heel traag)
-					delay: 0.1
-				});
-			};
-
-			// Voer animaties uit bij component mount
-			applyAnimations();
-
-			// Maak ResizeObserver om grid changes te detecteren
-			const observer = new ResizeObserver(applyAnimations);
-			// Start met observeren van gridRef voor size changes
-			observer.observe(gridRef);
-			console.log(SplitText);
-
-			// Cleanup functie: wordt uitgevoerd bij component unmount
-			return () => {
-				observer.disconnect();
-				ScrollTrigger.getAll().forEach((trigger) => trigger.kill());
-			};
-		}
-	});
+    import { onMount } from 'svelte';
+    import { browser } from '$app/environment';
+    import { gsap } from '$lib/gsap-config'; 
+    import NetwerkCard from '$lib/components/molecules/NetwerkCard/NetwerkCard.svelte';
+    
+    // Props van parent component
+    let { title = 'Netwerk', data } = $props();
+    
+    // Referentie naar het grid element in de DOM
+    let gridRef;
+    let titleElement;
+    
+    // Lifecycle hook: wordt uitgevoerd na component mount
+    onMount(async () => {
+        if (browser) {
+            const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            
+            // Importeer GSAP en ScrollTrigger dynamisch (code splitting)
+            const { ScrollTrigger } = await import('gsap/ScrollTrigger');
+            const { SplitText } = await import('gsap/SplitText');
+            
+            // Registreer ScrollTrigger plugin bij GSAP
+            gsap.registerPlugin(ScrollTrigger);
+            gsap.registerPlugin(SplitText);
+            
+            // Functie die de scroll animaties toepast
+            const applyAnimations = () => {
+                // Verwijder alle bestaande ScrollTriggers om duplicaten te voorkomen
+                ScrollTrigger.getAll().forEach((trigger) => trigger.kill());
+                
+                // Stop als gridRef nog niet bestaat
+                if (!gridRef) return;
+                
+                // Bepaal hoeveel kolommen het grid heeft
+                const columnCount = window
+                    .getComputedStyle(gridRef)
+                    .getPropertyValue('grid-template-columns')
+                    .split(' ').length; // Tel aantal kolommen
+                
+                // Selecteer alle cards
+                const allCards = gridRef.querySelectorAll('.card-wrapper');
+                
+                if (!prefersReducedMotion) {
+                    // Alleen title animatie bij geen reduced motion
+                    const split = new SplitText(titleElement, { type: 'chars' });
+                    gsap.from(split.chars, {
+                        y: '100%',
+                        opacity: 0,
+                        duration: 1.2,
+                        stagger: 0.03,
+                        ease: 'power4.out',
+                        delay: 0.1
+                    });
+                }
+                
+                // Als er 4 of meer kolommen zijn, pas effect toe
+                if (columnCount >= 4) {
+                    // Selecteer alle cards in kolom 1 (1e, 5e, 9e, etc.)
+                    const column1Cards = gridRef.querySelectorAll('.card-wrapper:nth-child(4n+1)');
+                    // Selecteer alle cards in kolom 3 (3e, 7e, 11e, etc.)
+                    const column3Cards = gridRef.querySelectorAll('.card-wrapper:nth-child(4n+3)');
+                    
+                    if (!prefersReducedMotion) {
+                        // Alleen offset + animatie bij geen reduced motion
+                        allCards.forEach((card) => card.classList.remove('no-offset'));
+                        column1Cards.forEach((card) => card.classList.add('offset'));
+                        column3Cards.forEach((card) => card.classList.add('offset'));
+                        
+                        // Timeline voor beide kolommen
+                        const tl = gsap.timeline({
+                            scrollTrigger: {
+                                trigger: gridRef,
+                                start: 'top bottom',
+                                end: 'bottom top',
+                                scrub: true
+                            }
+                        });
+                        
+                        // Animeer van CSS positie (250px) naar -250px
+                        tl.to(
+                            [column1Cards, column3Cards],
+                            {
+                                y: -250,
+                                ease: 'none',
+                                overwrite: 'auto'
+                            },
+                            0
+                        );
+                    } else {
+                        // Bij reduced motion: alle cards op y: 0
+                        allCards.forEach((card) => {
+                            card.classList.remove('offset');
+                            card.classList.add('no-offset');
+                        });
+                        gsap.set(allCards, { y: 0, clearProps: 'transform' });
+                    }
+                } else {
+                    // Bij minder dan 4 kolommen: verwijder offset class en reset
+                    allCards.forEach((card) => {
+                        card.classList.remove('offset');
+                        card.classList.add('no-offset');
+                    });
+                    gsap.set(allCards, { clearProps: 'all' });
+                }
+            };
+            
+            // Voer animaties uit bij component mount
+            applyAnimations();
+            
+            // Maak ResizeObserver om grid changes te detecteren
+            const observer = new ResizeObserver(applyAnimations);
+            
+            // Start met observeren van gridRef voor size changes
+            observer.observe(gridRef);
+            
+            // Cleanup functie: wordt uitgevoerd bij component unmount
+            return () => {
+                observer.disconnect();
+                ScrollTrigger.getAll().forEach((trigger) => trigger.kill());
+            };
+        }
+    });
 </script>
 
 <section class="container">

--- a/src/routes/projecten/+page.svelte
+++ b/src/routes/projecten/+page.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { onMount } from 'svelte';
 	import { browser } from '$app/environment';
+	import { gsap } from '$lib/gsap-config'; 
 
 	import ProjectCard from '$lib/components/molecules/ProjectCard/ProjectCard.svelte';
 
@@ -8,28 +9,28 @@
 	let { projects } = data;
 
 	let titleElement;
-
-	onMount(async () => {
-		if (browser) {
-			const { gsap } = await import('gsap');
-			const { SplitText } = await import('gsap/SplitText');
-
-			gsap.registerPlugin(SplitText);
-
-			// We splitsen de tekst in karakters
-			const split = new SplitText(titleElement, { type: 'chars' });
-
-			gsap.from(split.chars, {
-				y: '100%', // Start precies onder de regel
-				opacity: 0, // Subtiele fade-in erbij
-				duration: 1.2, // Iets langer voor een rustig gevoel
-				stagger: 0.03, // Heel kort achter elkaar voor een vloeiende beweging
-				ease: 'power4.out', // De meest 'high-end' easing (start vlot, eindigt heel traag)
-				delay: 0.1
-			});
-
-			return () => split.revert();
-		}
+    
+    onMount(async () => {
+        if (browser) {
+            const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            
+            if (!prefersReducedMotion) {
+                // Alleen animeren als reduced motion UIT staat
+                const { SplitText } = await import('gsap/SplitText');
+                gsap.registerPlugin(SplitText);
+                
+                const split = new SplitText(titleElement, { type: 'chars' });
+                gsap.from(split.chars, {
+                    y: '100%',
+                    opacity: 0,
+                    duration: 1.2,
+                    stagger: 0.03,
+                    ease: 'power4.out',
+                    delay: 0.1
+                });
+            }
+            // Bij reduced motion: title blijft gewoon zichtbaar (SplitText wordt niet uitgevoerd)
+        }
 	});
 </script>
 


### PR DESCRIPTION
## What does this change?

Resolves issues #250, #255 

Ik heb de projecten links beschreven met aria labelled by. Hiermee koppelt de link aan de titel van het project.

Alle animaties:
- Triggeren nu bij in beeld scrollen (niet bij pagina laden)
- Respecteren gebruikers motion voorkeuren
- Tonen elementen in eindstaat wanneer reduced motion is ingeschakeld

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?
<!-- Link to test results in the Wiki-->

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [ ] [Responsive Design test]()
- [ ] [Device test]()
- [ ] [Browser test]()

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Zet reduced motion aan en kijk of alles goed is op de website en of je geen animaties ziet
